### PR TITLE
Make `test_rng` randomized by default in `std`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes
 
-- [\#32](https://github.com/arkworks-rs/utils/pull/32) Change `test_rng` to return `impl Rng`, and make the output randomized by default when the `std` feature is set. Introduces a `DETERMINISTIC_TEST_RNG` environment variable that forces the old deterministic behavior when `DETERMINISTIC_TEST_RNG=1` is set.
+- [\#35](https://github.com/arkworks-rs/utils/pull/35) Change `test_rng` to return `impl Rng`, and make the output randomized by default when the `std` feature is set. Introduces a `DETERMINISTIC_TEST_RNG` environment variable that forces the old deterministic behavior when `DETERMINISTIC_TEST_RNG=1` is set.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Breaking changes
 
+- [\#32](https://github.com/arkworks-rs/utils/pull/32) Change `test_rng` to return `impl Rng`, and make the output randomized by default when the `std` feature is set. Introduces a `DETERMINISTIC_TEST_RNG` environment variable that forces the old deterministic behavior when `DETERMINISTIC_TEST_RNG=1` is set.
+
 ### Features
 
 ### Improvements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = { version = "0.2", default-features = false }
 
 [features]
 default = [ "std" ]
-std = []
+std = [ "rand/std" ]
 parallel = [ "rayon", "std" ]
 print-trace = [ "std", "colored" ]
 

--- a/src/rand_helper.rs
+++ b/src/rand_helper.rs
@@ -1,8 +1,10 @@
 use rand::{
     distributions::{Distribution, Standard},
-    rngs::StdRng,
+    prelude::StdRng,
     Rng,
 };
+#[cfg(feature = "std")]
+use rand::{prelude::ThreadRng, RngCore};
 
 pub use rand;
 
@@ -20,8 +22,7 @@ where
     }
 }
 
-/// Should be used only for tests, not for any real world usage.
-pub fn test_rng() -> StdRng {
+fn test_rng_helper() -> StdRng {
     use rand::SeedableRng;
     // arbitrary seed
     let seed = [
@@ -29,4 +30,90 @@ pub fn test_rng() -> StdRng {
         0, 0, 0, 0,
     ];
     rand::rngs::StdRng::from_seed(seed)
+}
+
+/// Should be used only for tests, not for any real world usage.
+#[cfg(not(feature = "std"))]
+pub fn test_rng() -> impl rand::Rng {
+    test_rng_helper()
+}
+
+/// Should be used only for tests, not for any real world usage.
+#[cfg(feature = "std")]
+pub fn test_rng() -> impl rand::Rng {
+    let is_deterministic =
+        std::env::vars().any(|(key, val)| key == "DETERMINISTIC_TEST_RNG" && val == "1");
+    if is_deterministic {
+        RngWrapper::Deterministic(test_rng_helper())
+    } else {
+        RngWrapper::Randomized(rand::thread_rng())
+    }
+}
+
+/// Helper wrapper to enable `test_rng` to return `impl::Rng`.
+#[cfg(feature = "std")]
+enum RngWrapper {
+    Deterministic(StdRng),
+    Randomized(ThreadRng),
+}
+
+#[cfg(feature = "std")]
+impl RngCore for RngWrapper {
+    #[inline(always)]
+    fn next_u32(&mut self) -> u32 {
+        match self {
+            Self::Deterministic(rng) => rng.next_u32(),
+            Self::Randomized(rng) => rng.next_u32(),
+        }
+    }
+
+    #[inline(always)]
+    fn next_u64(&mut self) -> u64 {
+        match self {
+            Self::Deterministic(rng) => rng.next_u64(),
+            Self::Randomized(rng) => rng.next_u64(),
+        }
+    }
+
+    #[inline(always)]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        match self {
+            Self::Deterministic(rng) => rng.fill_bytes(dest),
+            Self::Randomized(rng) => rng.fill_bytes(dest),
+        }
+    }
+
+    #[inline(always)]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        match self {
+            Self::Deterministic(rng) => rng.try_fill_bytes(dest),
+            Self::Randomized(rng) => rng.try_fill_bytes(dest),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    #[test]
+    fn test_deterministic_rng() {
+        use super::*;
+
+        let mut rng = super::test_rng();
+        let a = u128::rand(&mut rng);
+
+        // Reset the rng by sampling a new one.
+        let mut rng = super::test_rng();
+        let b = u128::rand(&mut rng);
+        assert_ne!(a, b); // should be unequal with high probability.
+
+        // Let's make the rng deterministic.
+        std::env::set_var("DETERMINISTIC_TEST_RNG", "1");
+        let mut rng = super::test_rng();
+        let a = u128::rand(&mut rng);
+
+        // Reset the rng by sampling a new one.
+        let mut rng = super::test_rng();
+        let b = u128::rand(&mut rng);
+        assert_eq!(a, b); // should be unequal with high probability.
+    }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Makes `test_rng` use a randomized seed by default when `std` is set. The benefit of this is that our "fuzzing" tests actually explore the search space now. Longer term we should also introduce a fuzzing harness to explicitly perform the search. To recover the old deterministic behaviour, the user can set `env DETERMINISTIC_TEST_RNG=1` when running tests.

Also makes the output of `test_rng` opaque to the user, by having it return `impl Rng` instead.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (master)
- [x] ~Linked to Github issue with discussion and accepted design OR~ have an explanation in the PR that describes this work.
- [X] Wrote unit tests
- [X] Updated relevant documentation in the code
- [X] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
