### PR TITLE
Fix potential clippy issue of unused variable for `start_timer` and `add_to_trace` macros for not `print-trace` feature

### DIFF
--- a/src/perf_trace.rs
+++ b/src/perf_trace.rs
@@ -183,14 +183,16 @@ mod inner {
 
     #[macro_export]
     macro_rules! start_timer {
-        ($msg:expr) => {
+        ($msg:expr) => {{
+            let _ = $msg;
             $crate::perf_trace::TimerInfo
-        };
+        }};
     }
     #[macro_export]
     macro_rules! add_to_trace {
         ($title:expr, $msg:expr) => {
             let _ = $msg;
+            let _ = $title;
         };
     }
 


### PR DESCRIPTION
## Description

It seems that it may cause Clippy issue of unused variable when calling `start_timer` (or `add_to_trace`) with `not(feature = "print-trace")` as:
```
let number = 10;
start_timer!(|| format!("Current NO-{number}"));
```

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer