### PR TITLE
Fix incorrect use of atomic variable in `src/perf_trace.rs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Pending
+- [\#47](https://github.com/arkworks-rs/std/pull/47) Fix incorrect use of atomic variable in `src/perf_trace.rs`
 
 ### Breaking changes
 

--- a/src/perf_trace.rs
+++ b/src/perf_trace.rs
@@ -66,11 +66,10 @@ pub mod inner {
 
             let msg = $msg();
             let start_info = "Start:".yellow().bold();
-            let indent_amount = 2 * NUM_INDENT.fetch_add(0, Ordering::Relaxed);
+            let indent_amount = 2 * NUM_INDENT.fetch_add(1, Ordering::Relaxed);
             let indent = compute_indent(indent_amount);
 
             $crate::perf_trace::println!("{}{:8} {}", indent, start_info, msg);
-            NUM_INDENT.fetch_add(1, Ordering::Relaxed);
             $crate::perf_trace::TimerInfo {
                 msg: msg.to_string(),
                 time: Instant::now(),
@@ -110,8 +109,7 @@ pub mod inner {
             let end_info = "End:".green().bold();
             let message = format!("{} {}", $time.msg, $msg());
 
-            NUM_INDENT.fetch_sub(1, Ordering::Relaxed);
-            let indent_amount = 2 * NUM_INDENT.fetch_add(0, Ordering::Relaxed);
+            let indent_amount = 2 * NUM_INDENT.fetch_sub(1, Ordering::Relaxed);
             let indent = compute_indent(indent_amount);
 
             // Todo: Recursively ensure that *entire* string is of appropriate
@@ -144,7 +142,7 @@ pub mod inner {
             let start_indent_amount = 2 * NUM_INDENT.fetch_add(0, Ordering::Relaxed);
             let start_indent = compute_indent(start_indent_amount);
 
-            let msg_indent_amount = 2 * NUM_INDENT.fetch_add(0, Ordering::Relaxed) + 2;
+            let msg_indent_amount = start_indent_amount + 2;
             let msg_indent = compute_indent_whitespace(msg_indent_amount);
             let mut final_message = "\n".to_string();
             for line in $msg().lines() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR changed a few lines in `src/perf_trace.rs` on atomic variable accessing and modifying. As far as I can see these duplicated `fetch_add`s makes the entire macro non-atomic and should be merged into one.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

I could use some suggestions on how such unit test can be designed. And I believe this is a merely bug fix and no relevant documentation needs to be updated.
