### PR TITLE
Disable Rand Dependency When Feature Unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Pending
 
+Set the Rand depenency to optional
+
 ### Breaking changes
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 edition = "2021"
 
 [dependencies]
-rand = { version = "0.8", default-features = false, features = ["std_rng"]}
+rand = { version = "0.8", optional = true, default-features = false, features = ["std_rng"]}
 rayon = { version = "1", optional = true }
 colored = { version = "2", optional = true }
 num-traits = { version = "0.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,9 @@ pub mod sync {
     pub use std::sync::*;
 }
 
+#[cfg(feature = "std")]
 mod rand_helper;
+#[cfg(feature = "std")]
 pub use rand_helper::*;
 
 pub mod perf_trace;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The rand and getrandom libraries are a particular nuisance when trying to compile Rust to certain architectures, like wasm. 

This PR sets the rand dependency to optional, meaning it will not enter the dependency tree when features don't call for it, and should allow wasm compilation to complete

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [?] Wrote unit tests
- [?] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
